### PR TITLE
Use default parameters for hifiasm

### DIFF
--- a/workflow/rules/1.assembly/01.hifiasm.smk
+++ b/workflow/rules/1.assembly/01.hifiasm.smk
@@ -2,7 +2,7 @@ rule hifiasm:
     input:
         hifi = lambda wildcards: [config["reads"]["hifi"][wildcards.asmname][sample] for sample in config["reads"]["hifi"][wildcards.asmname]],
     output:
-        "results/{asmname}/1.assembly/01.hifiasm/{asmname}_hifi_only.p_ctg.gfa", #with `--primary -l0` option
+        "results/{asmname}/1.assembly/01.hifiasm/{asmname}_hifi_only.bp.p_ctg.gfa",
     log:
         "results/logs/1.assembly/hifiasm/{asmname}.log"
     benchmark:
@@ -12,14 +12,14 @@ rule hifiasm:
     conda:
         "../../envs/hifiasm.yaml"
     shell:
-        "hifiasm -t {threads} --primary -l0 -o $(echo {output} | rev | cut -d '.' -f 3- | rev) {input.hifi} 2> {log}"  # with `--primary -l0` option
+        "hifiasm -t {threads} -o $(echo {output} | rev | cut -d '.' -f 3- | rev) {input.hifi} 2> {log}"
 
 rule hifiasm_with_ont:
     input:
         hifi = lambda wildcards: [config["reads"]["hifi"][wildcards.asmname][sample] for sample in config["reads"]["hifi"][wildcards.asmname]],
         ont = lambda wildcards: [config["reads"]["ont"][wildcards.asmname][sample] for sample in config["reads"]["ont"][wildcards.asmname]],
     output:
-        "results/{asmname}/1.assembly/01.hifiasm/{asmname}_hifi_and_ont.p_ctg.gfa", #with `--primary -l0` option
+        "results/{asmname}/1.assembly/01.hifiasm/{asmname}_hifi_and_ont.bp.p_ctg.gfa",
     log:
         "results/logs/1.assembly/hifiasm_with_ont/{asmname}.log"
     benchmark:
@@ -29,13 +29,13 @@ rule hifiasm_with_ont:
     conda:
         "../../envs/hifiasm.yaml"
     shell:
-        "hifiasm -t {threads} --primary -l0 -o $(echo {output} | rev | cut -d '.' -f 3- | rev) --ul {input.ont} {input.hifi} 2> {log}"  # with `--primary -l0` option
+        "hifiasm -t {threads} -o $(echo {output} | rev | cut -d '.' -f 3- | rev) --ul {input.ont} {input.hifi} 2> {log}"
 
 rule gfa2fasta:
     input:
-        lambda wildcards: branch("ont" in config["reads"] and wildcards.asmname in config["reads"]["ont"],  #with `--primary -l0` option
-            then = "results/{asmname}/1.assembly/01.hifiasm/{asmname}_hifi_and_ont.p_ctg.gfa",
-            otherwise = "results/{asmname}/1.assembly/01.hifiasm/{asmname}_hifi_only.p_ctg.gfa"),
+        lambda wildcards: branch("ont" in config["reads"] and wildcards.asmname in config["reads"]["ont"],
+            then = "results/{asmname}/1.assembly/01.hifiasm/{asmname}_hifi_and_ont.bp.p_ctg.gfa",
+            otherwise = "results/{asmname}/1.assembly/01.hifiasm/{asmname}_hifi_only.bp.p_ctg.gfa"),
     output:
         "results/{asmname}/1.assembly/01.hifiasm/{asmname}.fa"
     log:


### PR DESCRIPTION
This PR removes the `--primary -l0` parameters from hifiasm. These were found not to improve the accuracy (QV) scores for lettuce, which is a mostly homozygous genome:

  | Overall QV (Illumina) | Overall QV (HiFi)
-- | -- | --
HiFi only; default | 44.44 | 49.88
HiFi only; `--primary -l0` | 44.40 | 49.85
HiFi+ONT; default | 44.51 | 49.13
HiFi+ONT; `--primary -l0` | 44.49 | 49.16
