### PR TITLE
Add mummerplot for contigs

### DIFF
--- a/workflow/report/mummerplot.rst
+++ b/workflow/report/mummerplot.rst
@@ -1,5 +1,6 @@
-This MUMmerplot shows the alignment of the scaffolded assembly against the
-defined reference genome ({{ snakemake.config["ref_genome"] }}).
+This MUMmerplot shows the alignment of the assembly at a given stage against the
+defined reference genome ({{ snakemake.config["ref_genome"] }}). Please see the
+"stage" label in the metadata whether **contigs** or **scaffolds** are shown.
 
-This plot can be used to verify the scaffolding and renaming process that is
-automated in this pipeline.
+This plot can be used to verify the assembly, scaffolding and renaming process
+that is automated in this pipeline.

--- a/workflow/rules/1.assembly/03.mummer.smk
+++ b/workflow/rules/1.assembly/03.mummer.smk
@@ -1,0 +1,53 @@
+rule get_reference_contigs:
+    input:
+        lambda wildcards: config["ref_genome"][wildcards.reference],
+    output:
+        temporary("results/{asmname}/1.assembly/03.mummer/{reference}.fa"),
+    log:
+        "results/logs/1.assembly/get_reference/{asmname}/{reference}.log"
+    benchmark:
+        "results/benchmarks/1.assembly/get_reference/{asmname}/{reference}.txt"
+    shell:
+        "cp {input} {output} &> {log}"
+
+rule mummer_contigs:
+    input:
+        reference = "results/{asmname}/1.assembly/03.mummer/{reference}.fa",
+        assembly = "results/{asmname}/1.assembly/02.contigs/{asmname}.min{minlen}.sorted.renamed.fa",
+    output:
+        "results/{asmname}/1.assembly/03.mummer/{asmname}.min{minlen}.vs.{reference}.delta",
+    log:
+        "results/logs/1.assembly/mummer/{reference}/{asmname}.min{minlen}.vs.{reference}.log"
+    benchmark:
+        "results/benchmarks/1.assembly/mummer/{reference}/{asmname}.min{minlen}.vs.{reference}.txt"
+    threads:
+        24
+    container:
+        "workflow/singularity/mummer/mummer-4.0.0rc1.sif"
+    shell:
+        "nucmer -t {threads} -l 1000 -g 1000 --prefix=$(echo {output} | rev | cut -d '.' -f 2- | rev) {input.reference} {input.assembly} &> {log}"
+
+rule dotplot_contigs:
+    input:
+        delta = "results/{asmname}/1.assembly/03.mummer/{asmname}.min{minlen}.vs.{reference}.delta",
+        reference = "results/{asmname}/1.assembly/03.mummer/{reference}.fa",
+    output:
+        gp = "results/{asmname}/1.assembly/03.mummer/{asmname}.min{minlen}.vs.{reference}.plot.gp",
+        png = report("results/{asmname}/1.assembly/03.mummer/{asmname}.min{minlen}.vs.{reference}.plot.png",
+            category="MUMmerplot",
+            caption="../../report/mummerplot.rst",
+            labels={"assembly": "{asmname}",
+                    "stage": "contigs"}),
+    log:
+        "results/logs/1.assembly/dotplot/{asmname}/{asmname}.min{minlen}.vs.{reference}.log"
+    benchmark:
+        "results/benchmarks/1.assembly/dotplot/{asmname}/{asmname}.min{minlen}.vs.{reference}.txt"
+    container:
+        "workflow/singularity/mummer/mummer-4.0.0rc1.sif"
+    shell:  #assumes input and output are in same directory
+        """
+        (
+        cd $(dirname {output.gp})
+        mummerplot --filter --png --large --prefix=$(basename {output.gp} | rev | cut -d'.' -f 2- | rev) --title {wildcards.asmname} $(basename {input.delta})
+        ) &> {log}
+        """

--- a/workflow/rules/1.assembly/all.smk
+++ b/workflow/rules/1.assembly/all.smk
@@ -1,11 +1,17 @@
 include: "01.hifiasm.smk"
 include: "02.contigs.smk"
+include: "03.mummer.smk"
 
 rule assemble:
     input:
         expand("results/{asmname}/1.assembly/02.contigs/{asmname}.min{minlen}.sorted.renamed.fa",
-                asmname=get_all_accessions(),
-                minlen=config["min_contig_len"]
-                ),
+            asmname=get_all_accessions(),
+            minlen=config["min_contig_len"]
+        ),
+        expand("results/{asmname}/1.assembly/03.mummer/{asmname}.min{minlen}.vs.{reference}.plot.gp",
+            asmname = get_all_accessions(),
+            minlen=config["min_contig_len"],
+            reference = config["ref_genome"]
+        ),
     output:
         touch("results/assembly.done")

--- a/workflow/rules/2.scaffolding/03.mummer.smk
+++ b/workflow/rules/2.scaffolding/03.mummer.smk
@@ -36,7 +36,8 @@ rule dotplot:
         png = report("results/{asmname}/2.scaffolding/03.mummer/{asmname}.vs.{reference}.plot.png",
             category="MUMmerplot",
             caption="../../report/mummerplot.rst",
-            labels={"assembly": "{asmname}"}),
+            labels={"assembly": "{asmname}",
+                    "stage": "scaffolds"}),
     log:
         "results/logs/2.scaffolding/dotplot/{asmname}/{asmname}.vs.{reference}.log"
     benchmark:


### PR DESCRIPTION
This PR adds a mummerplot for the contig level assembly (before scaffolding). This may help in investigating scaffolding related issues.