### PR TITLE
Fix defaults for MUMmer and SANS

### DIFF
--- a/workflow/rules/1.assembly/03.mummer.smk
+++ b/workflow/rules/1.assembly/03.mummer.smk
@@ -25,7 +25,7 @@ rule mummer_contigs:
     container:
         "workflow/singularity/mummer/mummer-4.0.0rc1.sif"
     shell:
-        "nucmer -t {threads} -l 1000 -g 1000 --prefix=$(echo {output} | rev | cut -d '.' -f 2- | rev) {input.reference} {input.assembly} &> {log}"
+        "nucmer -t {threads} -l 100 -g 100 --prefix=$(echo {output} | rev | cut -d '.' -f 2- | rev) {input.reference} {input.assembly} &> {log}"
 
 rule dotplot_contigs:
     input:

--- a/workflow/rules/2.scaffolding/03.mummer.smk
+++ b/workflow/rules/2.scaffolding/03.mummer.smk
@@ -25,7 +25,7 @@ rule mummer:
     container:
         "workflow/singularity/mummer/mummer-4.0.0rc1.sif"
     shell:
-        "nucmer -t {threads} -l 1000 -g 1000 --prefix=$(echo {output} | rev | cut -d '.' -f 2- | rev) {input.reference} {input.assembly} &> {log}"
+        "nucmer -t {threads} -l 100 -g 100 --prefix=$(echo {output} | rev | cut -d '.' -f 2- | rev) {input.reference} {input.assembly} &> {log}"
 
 rule dotplot:
     input:

--- a/workflow/rules/5.quality_control/05.pantools.smk
+++ b/workflow/rules/5.quality_control/05.pantools.smk
@@ -94,7 +94,7 @@ rule panproteome_gene_classification:
         """
         (
         pantools {params.jvm} gene_classification $(dirname {input})
-        [ ! -f {output.rscript} ] && touch {output.rscript}
+        if [ ! -f {output.rscript} ]; then touch {output.rscript}; fi
         ) &> {log}
         """
 

--- a/workflow/rules/5.quality_control/all.smk
+++ b/workflow/rules/5.quality_control/all.smk
@@ -57,6 +57,15 @@ def get_pantools_output(wildcards):
                     all_output.append(f"results/{asmset}/5.quality_control/05.pantools/panproteome_groups_DB/gene_classification/upset/output/genomes.pdf")  #pantools gene classification
     return all_output
 
+def get_sans_output(wildcards):
+    all_output = []
+    k = config["k_qc"]
+    bootstrap = 1000
+    for asmset in config["set"]:
+        if len(config["set"][asmset]) >= 4:  #phylogenetic networks only makes sense for 4+ genomes
+            all_output.append(f"results/{asmset}/5.quality_control/11.sans/{k}/{asmset}_b{bootstrap}.nexus")
+    return all_output
+
 def get_pangrowth_output(wildcards):
     all_output = []
     k = config["k_qc"]
@@ -83,7 +92,7 @@ rule qc:
         expand("results/{asmset}/5.quality_control/08.kmer-db/{k}/{asmset}.csv.mash.pdf", asmset=config["set"], k=config["k_qc"]),  #kmer distances
         expand("results/{asmset}/5.quality_control/09.mash/{asmset}.pdf", asmset=config["set"]), #mash distances
         expand("results/{asmset}/5.quality_control/10.ntsynt/{asmset}.k{mink}.w{minw}.png", asmset=config["set"], mink=24, minw=1000), #ntsynt
-        expand("results/{asmset}/5.quality_control/11.sans/{k}/{asmset}_b{bootstrap}.nexus", k=config["k_qc"], asmset=config["set"], bootstrap=1000),  #sans nexus file (genome only with 1000 bootstrap)
+        get_sans_output,  #sans nexus file (genome only with 1000 bootstrap)
         get_pangrowth_output,  #pangrowth
         expand("results/{asmset}/5.quality_control/13.statistics/{asmset}.html", asmset=config["set"]),  #statistics
     output:


### PR DESCRIPTION
This PR fixes the following things:
- Change default parameters for `nucmer` from 100 to 1000
- Fix bug in touching Rscript if it's not created
- Only run SANS if there >= 4 genomes in a set