### PR TITLE
Fixing regex in schema validators

### DIFF
--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -42,7 +42,7 @@ properties:
           description: chromosomes of the reference genome
           additionalProperties:
             type: string
-            pattern: "^[a-zA-Z0-9_-]+$"
+            pattern: "^[a-zA-Z0-9_\\-\\.\\*:]+$"
 
   prot_queries:
     type: object

--- a/workflow/schemas/samples.schema.yaml
+++ b/workflow/schemas/samples.schema.yaml
@@ -26,7 +26,7 @@ properties:
   speciesName:
     type: string
     description: species name for naming Helixer genes
-    pattern: "^[a-zA-Z]+$"
+    pattern: "^[a-zA-Z0-9]+$"
   taxId:
     type: integer
     description: NCBI taxonomy ID for the accession


### PR DESCRIPTION
I noticed some mistakes in the regex validators in the schemas for the config and sample sheet:
- Fasta headers allow more characters than originally thought: https://www.ncbi.nlm.nih.gov/genbank/fastaformat/
- Species names for Helixer should be more flexible than originally thought