### PR TITLE
Some bugfixes with testing tabular input

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -38,8 +38,12 @@ reference_genomes:
             6: "Chr6"
 
 # All protein and nucleotide queries that need to be run for the assembly
-# analysis module (circos plot)
-prot_queries: #should be single exon domains only!
+# analysis module (circos plot). The key should be the name of the query and
+# the value should be the path to the query. At least one protein or nucleotide
+# query is required for the module to run.
+# NB: for the protein queries, the query should be a single exon domain as it
+# is searched in the genome.
+prot_queries:
     NBS_domain: "resources/blast_queries/query1.amac"
 nucl_queries:
     chloroplast: "resources/blast_queries/chloroplast.fasta"
@@ -66,6 +70,8 @@ set:
         - accessionB
         - accessionC
 
-# General settings
+# General settings; only change if you know what you are doing
 jvm: "-Xmx100g -Xms100g"  #java virtual machine settings
 tmpdir: "/dev/shm/"  #temporary directory for fast IO
+nucmer_maxgap: 1000  #maximum gap size for nucmer
+nucmer_minmatch: 1000  #minimum match size for nucmer

--- a/workflow/rules/1.assembly/03.mummer.smk
+++ b/workflow/rules/1.assembly/03.mummer.smk
@@ -20,12 +20,15 @@ rule mummer_contigs:
         "results/logs/1.assembly/mummer/{reference}/{asmname}.min{minlen}.vs.{reference}.log"
     benchmark:
         "results/benchmarks/1.assembly/mummer/{reference}/{asmname}.min{minlen}.vs.{reference}.txt"
+    params:
+        nucmer_maxgap = config["nucmer_maxgap"],
+        nucmer_minmatch = config["nucmer_minmatch"],
     threads:
         24
     container:
         "workflow/singularity/mummer/mummer-4.0.0rc1.sif"
     shell:
-        "nucmer -t {threads} -l 100 -g 100 --prefix=$(echo {output} | rev | cut -d '.' -f 2- | rev) {input.reference} {input.assembly} &> {log}"
+        "nucmer -t {threads} -l {params.nucmer_maxgap} -g {params.nucmer_minmatch} --prefix=$(echo {output} | rev | cut -d '.' -f 2- | rev) {input.reference} {input.assembly} &> {log}"
 
 rule dotplot_contigs:
     input:

--- a/workflow/rules/2.scaffolding/03.mummer.smk
+++ b/workflow/rules/2.scaffolding/03.mummer.smk
@@ -20,12 +20,15 @@ rule mummer:
         "results/logs/2.scaffolding/mummer/{reference}/{asmname}.vs.{reference}.log"
     benchmark:
         "results/benchmarks/2.scaffolding/mummer/{reference}/{asmname}.vs.{reference}.txt"
+    params:
+        nucmer_maxgap = config["nucmer_maxgap"],
+        nucmer_minmatch = config["nucmer_minmatch"],
     threads:
         24
     container:
         "workflow/singularity/mummer/mummer-4.0.0rc1.sif"
     shell:
-        "nucmer -t {threads} -l 100 -g 100 --prefix=$(echo {output} | rev | cut -d '.' -f 2- | rev) {input.reference} {input.assembly} &> {log}"
+        "nucmer -t {threads} -l {params.nucmer_maxgap} -g {params.nucmer_minmatch} --prefix=$(echo {output} | rev | cut -d '.' -f 2- | rev) {input.reference} {input.assembly} &> {log}"
 
 rule dotplot:
     input:

--- a/workflow/rules/5.quality_control/all.smk
+++ b/workflow/rules/5.quality_control/all.smk
@@ -53,6 +53,31 @@ def get_pantools_output(wildcards):
                     all_output.append(f"results/{asmset}/5.quality_control/05.pantools/panproteome_groups_DB/gene_classification/upset/output/genomes.pdf")  #pantools gene classification
     return all_output
 
+def get_kmerdb_output(wildcards):
+    all_output = []
+    k = config["k_qc"]
+    for asmset in config["set"]:
+        if len(config["set"][asmset]) >= 2:
+            all_output.append(f"results/{asmset}/5.quality_control/08.kmer-db/{k}/{asmset}.csv.mash.pdf"),  #kmer distances
+    return all_output
+
+
+def get_mash_output(wildcards):
+    all_output = []
+    for asmset in config["set"]:
+        if len(config["set"][asmset]) >= 2:
+            all_output.append(f"results/{asmset}/5.quality_control/09.mash/{asmset}.pdf"),  #mash distances
+    return all_output
+
+def get_ntsynt_output(wildcards):
+    all_output = []
+    mink = 24
+    minw = 1000
+    for asmset in config["set"]:
+        if len(config["set"][asmset]) >= 2:  #synteny only makes sense for multiple genomes
+            all_output.append(f"results/{asmset}/5.quality_control/10.ntsynt/{asmset}.k{mink}.w{minw}.png")
+    return all_output
+
 def get_sans_output(wildcards):
     all_output = []
     k = config["k_qc"]
@@ -85,9 +110,9 @@ rule qc:
         get_pantools_output,  #pantools
         expand("results/{asmset}/5.quality_control/06.busco_plot/busco_figure.png", asmset=config["set"]),  #busco (proteome) and compleasm (genome)
         expand("results/{asmset}/5.quality_control/07.omark_plot.png", asmset=config["set"]),  #omark
-        expand("results/{asmset}/5.quality_control/08.kmer-db/{k}/{asmset}.csv.mash.pdf", asmset=config["set"], k=config["k_qc"]),  #kmer distances
-        expand("results/{asmset}/5.quality_control/09.mash/{asmset}.pdf", asmset=config["set"]), #mash distances
-        expand("results/{asmset}/5.quality_control/10.ntsynt/{asmset}.k{mink}.w{minw}.png", asmset=config["set"], mink=24, minw=1000), #ntsynt
+        get_kmerdb_output,  #kmer-db
+        get_mash_output,  #mash
+        get_ntsynt_output, #ntsynt
         get_sans_output,  #sans nexus file (genome only with 1000 bootstrap)
         get_pangrowth_output,  #pangrowth
         expand("results/{asmset}/5.quality_control/13.statistics/{asmset}.html", asmset=config["set"]),  #statistics


### PR DESCRIPTION
Adding the following changes from #21 :
- `nucmer` alignment settings have a default of `-g 1000 -l 1000` but these values can be overwritten in `config.yaml`.
- circos doesn't depend on presence of both protein and nucleotide queries, but now only requires at least one.
- kmer-db, mash and ntsynt only run with >=2 assemblies per set.