### PR TITLE
Update hifiasm to 0.19.9

### DIFF
--- a/workflow/envs/hifiasm.yaml
+++ b/workflow/envs/hifiasm.yaml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - hifiasm=0.19.5
+  - hifiasm=0.19.9


### PR DESCRIPTION
As title says; reason is to prevent a potential hifiasm assertion fail in 0.19.5 that was fixed in more recent versions.