### PR TITLE
Hotfix missing dependency bedtools.yaml

### DIFF
--- a/workflow/envs/bedtools.yaml
+++ b/workflow/envs/bedtools.yaml
@@ -3,3 +3,5 @@ channels:
   - bioconda
 dependencies:
   - bedtools=2.31.1
+  - tk=8.6.13
+  - perl=5.32.1


### PR DESCRIPTION
As title says; tk/tcl and perl were missing from yaml