### PR TITLE
Fix CDS phase liftoff

### DIFF
--- a/workflow/rules/4.annotation/01.liftoff.smk
+++ b/workflow/rules/4.annotation/01.liftoff.smk
@@ -24,3 +24,19 @@ rule liftoff:
         liftoff -p {threads} -copies -cds -polish -u $(dirname {output.polished})/unmapped_features.txt -dir $(dirname {output.polished})/intermediate_files -o {output.gff} -g {output.ref_annotation} {input.assembly} {output.ref_genome}
         ) &> {log}
         """
+
+rule fix_cds_phase_liftoff_gff_polished:
+    input:
+        polished = "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished",
+        assembly = "results/{asmname}/2.scaffolding/02.renaming/{asmname}.fa",
+        config = "results/{asmname}/agat_config.yaml",
+    output:
+        "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.gff3",
+    log:
+        "results/logs/4.annotation/fixed_cds_phase_liftoff_gff_polished/{asmname}.log"
+    benchmark:
+        "results/benchmarks/4.annotation/fixed_cds_phase_liftoff_gff_polished/{asmname}.txt"
+    conda:
+        "../../envs/agat.yaml"
+    shell:
+        "agat_sp_fix_cds_phases.pl --gff {input.polished} --fasta {input.assembly} --output {output} --config {input.config} &> {log}"

--- a/workflow/rules/4.annotation/03.combined.smk
+++ b/workflow/rules/4.annotation/03.combined.smk
@@ -1,6 +1,6 @@
 rule combine_liftoff_helixer:
     input:
-        liftoff = "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished",
+        liftoff = "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.gff3", # fixed CDS phase with AGAT
         helixer = "results/{asmname}/4.annotation/02.helixer/helixer.gff",
         config = "results/{asmname}/agat_config.yaml",
     output:


### PR DESCRIPTION
As title says; I noticed that LiftOff doesn't print any phase information for CDS. This has been fixed in an unreleased version of LiftOff but since AGAT has a script for it too, I opt to use that one. I tested it on arabidopsis and it works smoothly.