### PR TITLE
REMOVE flye from pipeline

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -10,7 +10,7 @@
 samples: "config/samples.tsv"
 
 # Assembly settings
-assembler: "hifiasm"  #supported assemblers: hifiasm, flye, verkko
+assembler: "hifiasm"  #supported assemblers: hifiasm, verkko
 
 # All filtering and scaffolding parameters
 min_contig_len: 10000

--- a/workflow/envs/flye.yaml
+++ b/workflow/envs/flye.yaml
@@ -1,5 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda
-dependencies:
-  - flye=2.9.4

--- a/workflow/rules/1.assembly/01.assembly.smk
+++ b/workflow/rules/1.assembly/01.assembly.smk
@@ -43,51 +43,6 @@ rule hifiasm_to_fasta:
     shell:
         "awk '/^S/{{print \">\"$2; print $3;}}' {input} > {output} 2> {log}"
 
-rule flye:
-    input:
-        hifi = get_hifi,
-    output:
-        "results/{asmname}/1.assembly/01.flye_hifi_only/assembly.fasta",
-    log:
-        "results/logs/1.assembly/flye_hifi_only/{asmname}.log"
-    benchmark:
-        "results/benchmarks/1.assembly/flye_hifi_only/{asmname}.txt"
-    threads:
-        min(max(workflow.cores - 1, 1), 50)
-    conda:
-        "../../envs/flye.yaml"
-    shell:
-        "flye --pacbio-hifi {input.hifi} --out-dir $(dirname {output}) --threads {threads} &> {log}"
-
-rule flye_with_ont:
-    input:
-        hifi = get_hifi,
-        ont = get_ont,
-    output:
-        "results/{asmname}/1.assembly/01.flye_hifi_and_ont/assembly.fasta",
-    log:
-        "results/logs/1.assembly/flye_hifi_and_ont/{asmname}.log"
-    benchmark:
-        "results/benchmarks/1.assembly/flye_hifi_and_ont/{asmname}.txt"
-    threads:
-        min(max(workflow.cores - 1, 1), 50)
-    conda:
-        "../../envs/flye.yaml"
-    shell:
-        "flye --pacbio-hifi {input.hifi} --nano-hq {input.ont} --out-dir $(dirname {output}) --threads {threads} &> {log}"
-
-rule flye_rename_fasta:
-    input:
-        "results/{asmname}/1.assembly/01.flye_{ext}/assembly.fasta",
-    output:
-        "results/{asmname}/1.assembly/01.flye_{ext}/{asmname}.fa",
-    log:
-        "results/logs/1.assembly/flye_{ext}_rename_fasta/{asmname}.log"
-    benchmark:
-        "results/benchmarks/1.assembly/flye_{ext}_rename_fasta/{asmname}.txt"
-    shell:
-        "cp {input} {output} &> {log}"
-
 rule verkko:
     input:
         hifi = get_hifi,

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -12,8 +12,8 @@ properties:
 
   assembler:
     type: string
-    description: assembler to use; supported assemblers are hifiasm, flye, verkko
-    pattern: "^(hifiasm|flye|verkko)$"
+    description: assembler to use; supported assemblers are hifiasm, verkko
+    pattern: "^(hifiasm|verkko)$"
 
   min_contig_len:
     type: integer


### PR DESCRIPTION
I decided to remove `flye` from the pipeline for at least the time being, since the current set-up should allow for both hifi and ont input. Flye doesn't allow both for assembly.