### PR TITLE
Allow assembly of single genomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+All notable changes to MoGAAAP will be documented in this file.
+
+## [Unreleased]
+
+### Fixed
+- Allow set of size 1 in config (by ignoring them effectively) (#49)
+
+## [0.1.0] - 2024-10-14
+
+- First release (#43)

--- a/workflow/rules/5.quality_assessment/all.smk
+++ b/workflow/rules/5.quality_assessment/all.smk
@@ -46,6 +46,8 @@ def get_multiqc_output(wildcards):
 def get_pantools_output(wildcards):
     all_output = []
     for asmset in config["set"]:
+        if (len(get_all_accessions_from_asmset(asmset)) < 2):
+            continue
         all_output.append(f"results/{asmset}/5.quality_assessment/05.pantools/panproteome_groups_DB/pantools_homology_groups.txt")  #pantools homology grouping
         if len(config["set"][asmset]) >= 3:
             all_output.append(f"results/{asmset}/5.quality_assessment/05.pantools/panproteome_groups_DB/pangenome_size/gene/core_dispensable_growth.png")  #pantools pangenome growth
@@ -57,6 +59,8 @@ def get_kmerdb_output(wildcards):
     all_output = []
     k = config["k_qa"]
     for asmset in config["set"]:
+        if (len(get_all_accessions_from_asmset(asmset)) < 2):
+            continue
         if len(config["set"][asmset]) >= 2:
             all_output.append(f"results/{asmset}/5.quality_assessment/08.kmer-db/{k}/{asmset}.csv.mash.pdf"),  #kmer distances
     return all_output
@@ -65,6 +69,8 @@ def get_kmerdb_output(wildcards):
 def get_mash_output(wildcards):
     all_output = []
     for asmset in config["set"]:
+        if (len(get_all_accessions_from_asmset(asmset)) < 2):
+            continue
         if len(config["set"][asmset]) >= 2:
             all_output.append(f"results/{asmset}/5.quality_assessment/09.mash/{asmset}.pdf"),  #mash distances
     return all_output
@@ -74,6 +80,8 @@ def get_ntsynt_output(wildcards):
     mink = 24
     minw = 1000
     for asmset in config["set"]:
+        if (len(get_all_accessions_from_asmset(asmset)) < 2):
+            continue
         if len(config["set"][asmset]) >= 2:  #synteny only makes sense for multiple genomes
             all_output.append(f"results/{asmset}/5.quality_assessment/10.ntsynt/{asmset}.k{mink}.w{minw}.png")
     return all_output
@@ -83,6 +91,8 @@ def get_sans_output(wildcards):
     k = config["k_qa"]
     bootstrap = 1000
     for asmset in config["set"]:
+        if (len(get_all_accessions_from_asmset(asmset)) < 2):
+            continue
         if len(config["set"][asmset]) >= 4:  #phylogenetic networks only makes sense for 4+ genomes
             all_output.append(f"results/{asmset}/5.quality_assessment/11.sans/{k}/{asmset}_b{bootstrap}.nexus")
     return all_output
@@ -91,6 +101,8 @@ def get_pangrowth_output(wildcards):
     all_output = []
     k = config["k_qa"]
     for asmset in config["set"]:
+        if (len(get_all_accessions_from_asmset(asmset)) < 2):
+            continue
         if len(config["set"][asmset]) >= 3:
             all_output.append(f"results/{asmset}/5.quality_assessment/12.pangrowth/{k}/hist.pdf"),  #pangrowth hist
             all_output.append(f"results/{asmset}/5.quality_assessment/12.pangrowth/{k}/growth.pdf"),  #pangrowth growth

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -26,9 +26,9 @@ def get_all_accessions_from_asmset(asmset):
         for hap in range(1,haplotypes + 1)
         if accession in config["set"][asmset]
     ]
-    if len(accessions) < 2:
-        print(f'ERROR: set {asmset} appears to be empty!')
-        raise ValueError("something went wrong in obtaining set")
+    if len(accessions) == 1:
+        print(f'WARNING: set "{asmset}" appears to contain only one entry! Treating as if empty.')
+        accessions = []
     return accessions
 
 def get_hifi(wildcards):


### PR DESCRIPTION
Currently, the sets in config.yaml cannot be empty which gives a problem for when only one accession is registered in samples.tsv This PR will fix that by effectively treating sets of size 1 as if they are empty.