### PR TITLE
Create clean annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 All notable changes to MoGAAAP will be documented in this file.
 
+## [Unreleased]
+
+## Added
+- Add clean GFF file: only necessary attributes and clean names (#60).
+
+## Changed
+- Remove invalid ORFs from Liftoff output (#60).
+
 ## [0.2.0] - 2024-11-07
 
 ## Added

--- a/workflow/envs/agat.yaml
+++ b/workflow/envs/agat.yaml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - agat=1.4.0
+  - agat=1.4.1

--- a/workflow/rules/4.annotation/01.liftoff.smk
+++ b/workflow/rules/4.annotation/01.liftoff.smk
@@ -40,3 +40,31 @@ rule fix_cds_phase_liftoff_gff_polished:
         "../../envs/agat.yaml"
     shell:
         "agat_sp_fix_cds_phases.pl --gff {input.polished} --fasta {input.assembly} --output {output} --config {input.config} &> {log}"
+
+rule get_mRNA_with_valid_ORF: # get mRNA with valid ORF and other RNA
+    input:
+        "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.gff3",
+    output:
+        "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.valid_ORF.txt",
+    log:
+        "results/logs/4.annotation/get_mRNA_with_valid_ORF/{asmname}.log"
+    benchmark:
+        "results/benchmarks/4.annotation/get_mRNA_with_valid_ORF/{asmname}.txt"
+    shell:
+        "awk 'BEGIN{{FS = OFS = \"\\t\";}} ($3==\"mRNA\" && $9~/valid_ORF=True/) || $3~/[^m]RNA$/ {{split($9,a,\";\"); for (i in a){{if (a[i]~/^ID=/){{split(a[i],id,\"=\"); print id[2];}}}}}}' {input} > {output} 2> {log}"
+
+rule filter_valid_ORF_mRNA:
+    input:
+        gff = "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.gff3",
+        valid_ORF = "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.valid_ORF.txt",
+        config = "results/{asmname}/agat_config.yaml",
+    output:
+        "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.valid_ORF.gff3",
+    log:
+        "results/logs/4.annotation/filter_valid_ORF_mRNA/{asmname}.log"
+    benchmark:
+        "results/benchmarks/4.annotation/filter_valid_ORF_mRNA/{asmname}.txt"
+    conda:
+        "../../envs/agat.yaml"
+    shell:
+        "agat_sp_filter_feature_from_keep_list.pl --gff {input.gff} --keep_list {input.valid_ORF} --output {output} --config {input.config} &> {log}"

--- a/workflow/rules/4.annotation/01.liftoff.smk
+++ b/workflow/rules/4.annotation/01.liftoff.smk
@@ -31,7 +31,7 @@ rule fix_cds_phase_liftoff_gff_polished:
         assembly = "results/{asmname}/2.scaffolding/02.renaming/{asmname}.fa",
         config = "results/{asmname}/agat_config.yaml",
     output:
-        "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.gff3",
+        "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.gff",
     log:
         "results/logs/4.annotation/fixed_cds_phase_liftoff_gff_polished/{asmname}.log"
     benchmark:
@@ -43,7 +43,7 @@ rule fix_cds_phase_liftoff_gff_polished:
 
 rule get_mRNA_with_valid_ORF: # get mRNA with valid ORF and other RNA
     input:
-        "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.gff3",
+        "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.gff",
     output:
         "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.valid_ORF.txt",
     log:
@@ -55,11 +55,11 @@ rule get_mRNA_with_valid_ORF: # get mRNA with valid ORF and other RNA
 
 rule filter_valid_ORF_mRNA:
     input:
-        gff = "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.gff3",
+        gff = "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.gff",
         valid_ORF = "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.valid_ORF.txt",
         config = "results/{asmname}/agat_config.yaml",
     output:
-        "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.valid_ORF.gff3",
+        "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.valid_ORF.gff",
     log:
         "results/logs/4.annotation/filter_valid_ORF_mRNA/{asmname}.log"
     benchmark:
@@ -67,4 +67,4 @@ rule filter_valid_ORF_mRNA:
     conda:
         "../../envs/agat.yaml"
     shell:
-        "agat_sp_filter_feature_from_keep_list.pl --gff {input.gff} --keep_list {input.valid_ORF} --output {output} --config {input.config} &> {log}"
+        "agat_sp_filter_feature_from_keep_list.pl --gff {input.gff} --keep_list {input.valid_ORF} -l level2 --output {output} --config {input.config} &> {log}"

--- a/workflow/rules/4.annotation/01.liftoff.smk
+++ b/workflow/rules/4.annotation/01.liftoff.smk
@@ -41,22 +41,9 @@ rule fix_cds_phase_liftoff_gff_polished:
     shell:
         "agat_sp_fix_cds_phases.pl --gff {input.polished} --fasta {input.assembly} --output {output} --config {input.config} &> {log}"
 
-rule get_mRNA_with_valid_ORF: # get mRNA with valid ORF and other RNA
-    input:
-        "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.gff",
-    output:
-        "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.valid_ORF.txt",
-    log:
-        "results/logs/4.annotation/get_mRNA_with_valid_ORF/{asmname}.log"
-    benchmark:
-        "results/benchmarks/4.annotation/get_mRNA_with_valid_ORF/{asmname}.txt"
-    shell:
-        "awk 'BEGIN{{FS = OFS = \"\\t\";}} ($3==\"mRNA\" && $9~/valid_ORF=True/) || $3~/[^m]RNA$/ {{split($9,a,\";\"); for (i in a){{if (a[i]~/^ID=/){{split(a[i],id,\"=\"); print id[2];}}}}}}' {input} > {output} 2> {log}"
-
 rule filter_valid_ORF_mRNA:
     input:
         gff = "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.gff",
-        valid_ORF = "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.valid_ORF.txt",
         config = "results/{asmname}/agat_config.yaml",
     output:
         "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.valid_ORF.gff",
@@ -67,4 +54,4 @@ rule filter_valid_ORF_mRNA:
     conda:
         "../../envs/agat.yaml"
     shell:
-        "agat_sp_filter_feature_from_keep_list.pl --gff {input.gff} --keep_list {input.valid_ORF} -l level2 --output {output} --config {input.config} &> {log}"
+        "agat_sp_filter_feature_by_attribute_value.pl --gff {input.gff} --attribute valid_ORF --value False --output {output} --config {input.config} &> {log}"

--- a/workflow/rules/4.annotation/01.liftoff.smk
+++ b/workflow/rules/4.annotation/01.liftoff.smk
@@ -46,7 +46,9 @@ rule filter_valid_ORF_mRNA:
         gff = "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.gff",
         config = "results/{asmname}/agat_config.yaml",
     output:
-        "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.valid_ORF.gff",
+        gff = "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.valid_ORF.gff",
+        report = "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.valid_ORF_report.txt",
+        discarded = "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.valid_ORF_discarded.gff",
     log:
         "results/logs/4.annotation/filter_valid_ORF_mRNA/{asmname}.log"
     benchmark:
@@ -54,4 +56,4 @@ rule filter_valid_ORF_mRNA:
     conda:
         "../../envs/agat.yaml"
     shell:
-        "agat_sp_filter_feature_by_attribute_value.pl --gff {input.gff} -l level2 --attribute valid_ORF --value False --output {output} --config {input.config} &> {log}"
+        "agat_sp_filter_feature_by_attribute_value.pl --gff {input.gff} -l level2 --attribute valid_ORF --value False --output {output.gff} --config {input.config} &> {log}"

--- a/workflow/rules/4.annotation/01.liftoff.smk
+++ b/workflow/rules/4.annotation/01.liftoff.smk
@@ -54,4 +54,4 @@ rule filter_valid_ORF_mRNA:
     conda:
         "../../envs/agat.yaml"
     shell:
-        "agat_sp_filter_feature_by_attribute_value.pl --gff {input.gff} --attribute valid_ORF --value False --output {output} --config {input.config} &> {log}"
+        "agat_sp_filter_feature_by_attribute_value.pl --gff {input.gff} -l level2 --attribute valid_ORF --value False --output {output} --config {input.config} &> {log}"

--- a/workflow/rules/4.annotation/03.combined.smk
+++ b/workflow/rules/4.annotation/03.combined.smk
@@ -1,6 +1,6 @@
 rule combine_liftoff_helixer:
     input:
-        liftoff = "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.gff3", # fixed CDS phase with AGAT
+        liftoff = "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.valid_ORF.gff3", # fixed CDS phase and removed transcripts with invalid ORF
         helixer = "results/{asmname}/4.annotation/02.helixer/helixer.gff",
         config = "results/{asmname}/agat_config.yaml",
     output:
@@ -50,3 +50,35 @@ rule filter_coding_genes:
         "../../envs/agat.yaml"
     shell:
         "agat_sp_filter_feature_from_keep_list.pl --gff {input.original} --keep_list {input.coding_genes} --output {output} --config {input.config} &> {log}"
+
+rule remove_attributes_gff:
+    input:
+        original = "results/{asmname}/4.annotation/03.combined/{asmname}.gff",
+        config = "results/{asmname}/agat_config.yaml",
+    output:
+        temporary("results/{asmname}/4.annotation/03.combined/{asmname}.no_attr.gff"),
+    log:
+        "results/logs/4.annotation/remove_attributes_gff/{asmname}.log"
+    benchmark:
+        "results/benchmarks/4.annotation/remove_attributes_gff/{asmname}.txt"
+    conda:
+        "../../envs/agat.yaml"
+    shell:
+        "agat_sq_manage_attributes.pl --gff {input.original} --tag all_attributes --out {output} --config {input.config} &> {log}"
+
+rule create_clean_gff:
+    input:
+        original = "results/{asmname}/4.annotation/03.combined/{asmname}.no_attr.gff",
+        config = "results/{asmname}/agat_config.yaml",
+    output:
+        "results/{asmname}/4.annotation/03.combined/{asmname}.clean.gff",
+    log:
+        "results/logs/4.annotation/create_clean_gff/{asmname}.log"
+    benchmark:
+        "results/benchmarks/4.annotation/create_clean_gff/{asmname}.txt"
+    params:
+        species = lambda wildcards: get_species_name(wildcards),
+    conda:
+        "../../envs/agat.yaml"
+    shell:
+        "agat_sp_manage_IDs.pl --gff {input.original} --prefix {params.species} --tair --out {output} --config {input.config} &> {log}"

--- a/workflow/rules/4.annotation/03.combined.smk
+++ b/workflow/rules/4.annotation/03.combined.smk
@@ -1,6 +1,6 @@
 rule combine_liftoff_helixer:
     input:
-        liftoff = "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.valid_ORF.gff3", # fixed CDS phase and removed transcripts with invalid ORF
+        liftoff = "results/{asmname}/4.annotation/01.liftoff/liftoff.gff_polished.fixed.valid_ORF.gff", # fixed CDS phase and removed transcripts with invalid ORF
         helixer = "results/{asmname}/4.annotation/02.helixer/helixer.gff",
         config = "results/{asmname}/agat_config.yaml",
     output:

--- a/workflow/rules/4.annotation/all.smk
+++ b/workflow/rules/4.annotation/all.smk
@@ -6,9 +6,11 @@ rule copy_annotation:
     input:
         full = "results/{asmname}/4.annotation/03.combined/{asmname}.gff",
         coding = "results/{asmname}/4.annotation/03.combined/{asmname}.coding.gff",
+        clean = "results/{asmname}/4.annotation/03.combined/{asmname}.clean.gff",
     output:
         full = protected("final_output/{asmname}.full.gff"),
         coding = protected("final_output/{asmname}.full.coding.gff"),
+        clean = protected("final_output/{asmname}.clean.gff"),
     log:
         "results/logs/4.annotation/copy_annotation/{asmname}.log"
     benchmark:
@@ -18,6 +20,7 @@ rule copy_annotation:
         (
         cp {input.full} {output.full}
         cp {input.coding} {output.coding}
+        cp {input.clean} {output.clean}
         ) &> {log}
         """
 
@@ -25,5 +28,6 @@ rule annotate:
     input:
         expand("final_output/{asmname}.full.gff", asmname=get_all_accessions()),
         expand("final_output/{asmname}.full.coding.gff", asmname=get_all_accessions()),
+        expand("final_output/{asmname}.clean.gff", asmname=get_all_accessions()),
     output:
         touch("results/annotation.done")


### PR DESCRIPTION
Although the current GFF3 output is very useful, it takes some more steps before it could be submitted to e.g. NCBI. Therefore, this PR makes a couple small changes of how these GFF3 files are created:
- [x] Remove invalid ORF coding transcripts from Liftoff prior to merging with Helixer.
- [x] Create `.clean.gff` as additional output GFF3 that is stripped of all unnecessary attributes and renamed with the user-provided species name.