### PR TITLE
Fix busco for mulitple haplotypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to MoGAAAP will be documented in this file.
 
 ## Fixed
 - Fix PanTools upset plot creation for accessions with 2 haplotypes (#65).
+- Fix the BUSCO plot when there are 2 haplotypes (#66).
 
 ## Added
 - More clearly mark in report which WGS data was used for which statistics (#64).

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -15,6 +15,12 @@ def get_clean_accession_id(asmname):
     """
     return asmname.split(".hap")[0]
 
+def get_haplotype_accession_id(asmname):
+    """
+    Return the haplotype for a given asmname.
+    """
+    return "hap" + asmname.split(".hap")[1]
+
 def get_all_accessions_from_asmset(asmset, minimum=2):
     """
     Return all accession IDs for a given set, while taking care of haplotypes if needed
@@ -68,6 +74,9 @@ def get_hic_2(wildcards):
 
 def get_haplotypes(wildcards):
     return int(SAMPLES[SAMPLES["accessionId"] == get_clean_accession_id(wildcards.asmname)]["haplotypes"].values.item())
+
+def get_haplotype_information(asmname):
+    return int(SAMPLES[SAMPLES["accessionId"] == get_clean_accession_id(asmname)]["haplotypes"].values.item())
 
 def get_species_name(wildcards):
     return SAMPLES[SAMPLES["accessionId"] == get_clean_accession_id(wildcards.asmname)]["speciesName"].values.item()


### PR DESCRIPTION
In the BUSCO plot, a dot based separation is used to retrieve the names of the individual rows. However, in our pipeline we use `{asmname}.{haplotype}_{type}` which causes all haplotypes and types (genome/proteome) to be added together. I fix that here by only replacing the first dot for an underscore for BUSCO specifically.