### PR TITLE
Prevent duplicate chromosome names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to MoGAAAP will be documented in this file.
 ## Fixed
 - Fix PanTools upset plot creation for accessions with 2 haplotypes (#65).
 - Fix the BUSCO plot when there are 2 haplotypes (#66).
+- Prevent duplicate chromosome names (#67).
 
 ## Added
 - More clearly mark in report which WGS data was used for which statistics (#64).

--- a/workflow/rules/2.scaffolding/02.renaming.smk
+++ b/workflow/rules/2.scaffolding/02.renaming.smk
@@ -18,7 +18,7 @@ rule create_renaming_table:
             sort | \
             uniq -c | \
             sort -nr | \
-            awk -vnum_chr="{params.num_chr}" 'BEGIN{{OFS = "\\t";}} FNR<=num_chr{{print $2,$3;}}' > {output}
+            awk -vnum_chr="{params.num_chr}" 'BEGIN{{OFS = "\\t";}} FNR<=num_chr && !a[$2] {{print $2,$3; a[$2]=1;}}' > {output}
         ) &> {log}
         """
 


### PR DESCRIPTION
Current naming of chromosomes seems to work perfectly, except in the case of sex chromosomes: when renaming the chromosomes of an XX individual (or hypothetically, ZZ), a duplicate chromosome is indicated because of the current enforcing of the total number of chromosomes. Fixing that here by ensuring that no chromosome is appointed more than once.

(Without this fix, the duplicate chromosome names cause an error with `seqkit`.)