### PR TITLE
Clarify telomere identification in config and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,5 +326,5 @@ A: While `seqtk` is more accurate in the boundaries of the telomere search, it c
 Therefore, we recommend to also run BLASTN with a fasta file containing 100x the telomere repeat sequence for identification of telomeres that are not at the ends of the chromosomes.
 
 ### Contact
-If the above information does not answer your question or solve your issue, feel free to open an issue on this GitHub page or send me an email over dirk[dash]jan[dot]vanworkum[at]wur[dot]nl.
+If the above information does not answer your question or solve your issue, feel free to open an issue on this GitHub page.
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Please carefully look at the `nucmer` alignment plot to check that the assembly 
 
 #### Overview
 The purpose of the analyse module is to create a genome-wide overview of the newly created assembly.
-It does this by running several user-defined queries (including organelle search) against the assembly using BLAST as well as a search for the telomere repeat sequence.
+It does this by running several user-defined queries (including organelle search) against the assembly using BLAST as well as a search for the telomere repeat sequence (please see [this note in the FAQ](#q-should-i-use-blastn-or-seqtk-for-the-telomere-search) for more information on telomere identification).
 The results of these queries are visualised in an HTML report file.
 Next to this, the user-defined queries are used to create a template `circos` configuration and plot.
 
@@ -320,6 +320,10 @@ The current workaround is to run:
 ```bash
 sed -E 's/([^l]) h-screen/\1/g' report.html > report_fixed.html
 ```
+
+### Q: Should I use BLASTN or seqtk for the telomere search?
+A: While `seqtk` is more accurate in the boundaries of the telomere search, it cannot identify telomeres that are not at the ends of the chromosomes.
+Therefore, we recommend to also run BLASTN with a fasta file containing 100x the telomere repeat sequence for identification of telomeres that are not at the ends of the chromosomes.
 
 ### Contact
 If the above information does not answer your question or solve your issue, feel free to open an issue on this GitHub page or send me an email over dirk[dash]jan[dot]vanworkum[at]wur[dot]nl.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -53,10 +53,11 @@ prot_queries:
     NBS_domain: "resources/blast_queries/query1.amac"
 nucl_queries:
     ribosome: "resources/blast_queries/ribosome.fasta"
+    telomere: "resources/blast_queries/telomere.fasta" #for blastn: should be a 100x repeat of the telomere motif to identify telomeres anywhere in the genome
 organellar:
     chloroplast: "resources/blast_queries/chloroplast.fasta"
     mitochondrion: "resources/blast_queries/mitochondrion.fasta"
-telomere_motif: "CCCTAAA"
+telomere_motif: "CCCTAAA" #for seqtk: it only identifies the motif at the end of a chromosome
 
 # Annotation settings
 helixer_model: "resources/land_plant_v0.3_a_0080.h5"


### PR DESCRIPTION
There was no clear reason why the user could use both `seqtk` and `blastn` for telomere identification; so we now explain what both tools can do.