### PR TITLE
Allow running pipeline without custom SIF files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,44 +1,49 @@
 All notable changes to MoGAAAP will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Add option to use pipeline without sudo rights to build custom singularity containers (#79).
+
 ## [0.2.4 - 2025-01-20]
 
-## Added
+### Added
 - Messages on start, success and error (#73).
 - RagTag is now available for scaffolding as alternative to ntJoin (#75).
 
 ## [0.2.3 - 2024-12-18]
 
-## Added
+### Added
 - Creation of extra large MUMmerplot (#70).
 
 ## [0.2.2 - 2024-12-11]
 
-## Fixed
+### Fixed
 - Fix PanTools upset plot creation for accessions with 2 haplotypes (#65).
 - Fix the BUSCO plot when there are 2 haplotypes (#66).
 - Prevent duplicate chromosome names (#67).
 
-## Added
+### Added
 - More clearly mark in report which WGS data was used for which statistics (#64).
 
 ## [0.2.1] - 2024-11-22
 
-## Added
+### Added
 - Add clean GFF file: only necessary attributes and clean names (#60).
 
-## Changed
+### Changed
 - Remove invalid ORFs from Liftoff output (#60).
 
 ## [0.2.0] - 2024-11-07
 
-## Added
+### Added
 - Add optional use of Hi-C during assembly and for visualising ntJoin contact map (#56).
 - Add k-mer completeness statistics (#57).
 - Use Illumina instead of HiFi for final stats if available (#57).
 
 ## [0.1.2] - 2024-10-24
 
-## Fixed
+### Fixed
 - Also fixed OMArk, BUSCO and statistics for the assembly of a single genome (#52).
 - Sometimes the mashmap environment broke due to lack of BLIS library, now added specifically to the mashmap environment (#52).
 - Due to updates to numpy, BUSCO was failing, now fixed by using a newer version of BUSCO (#52).

--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ This installation process requires root access, but typically a server admin can
 If not installed already, Singularity/Apptainer can be installed by following the instructions on their website: [apptainer.org](https://apptainer.org/docs/user/latest/quick_start.html).
 Make sure to install either Singularity version 3.7 or higher or Apptainer version 1.0 or higher.
 
+#### Singularity/Apptainer environment variables
+**NB**: For Singularity/Apptainer to work properly, some environment variables need to be set.
+The following ones are required to be set in your `.profile`, `.bashrc` or `.bash_profile`:
+- `SINGULARITY_BIND`/`APPTAINER_BIND`: To bind the paths inside the container to the paths on your system; make sure all relevant paths are included (working directory, database directory, etc.).
+- `SINGULARITY_NV`/`APPTAINER_NV`: To use the GPU inside the container; only required if you have a GPU.
+
+It is also recommended to set the following environment variable:
+- `SINGULARITY_CACHEDIR`/`APPTAINER_CACHEDIR`: To store the cache of the container outside of your home directory.
+
+#### Singularity/Apptainer setup
 **NB**: For running the pipeline, no root access or special permissions are required.
 However, the pipeline needs some SIF files that are not included in the repository.
 These need to be built using the provided DEF files, which requires `sudo` permissions.
@@ -61,13 +71,8 @@ Navigate to the `workflow/singularity` directory and run the following command f
 sudo singularity build ${NAME}.sif ${NAME}.def
 ```
 
-**NB**: For Singularity/Apptainer to work properly, some environment variables need to be set.
-The following ones are required to be set in your `.profile`, `.bashrc` or `.bash_profile`:
-- `SINGULARITY_BIND`/`APPTAINER_BIND`: To bind the paths inside the container to the paths on your system; make sure all relevant paths are included (working directory, database directory, etc.).
-- `SINGULARITY_NV`/`APPTAINER_NV`: To use the GPU inside the container; only required if you have a GPU.
-
-It is also recommended to set the following environment variable:
-- `SINGULARITY_CACHEDIR`/`APPTAINER_CACHEDIR`: To store the cache of the container outside of your home directory.
+In case you do not have `sudo` permissions, you can also use set the `custom_singularity` flag in the `config/config.yaml` file to `false` to disable all rules that require a custom Singularity container.
+This means that not all output will be generated that is described [below](#output).
 
 ### Snakemake
 Snakemake can be installed using `conda`/`mamba`:
@@ -334,4 +339,3 @@ Therefore, we recommend to also run BLASTN with a fasta file containing 100x the
 
 ### Contact
 If the above information does not answer your question or solve your issue, feel free to open an issue on this GitHub page.
-

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -9,6 +9,10 @@
 # ID should be defined.
 samples: "config/samples.tsv"
 
+# Whether custom singularity containers can be used. If set to false, not all
+# output will be available.
+custom_singularity: false
+
 # Assembly settings
 assembler: "hifiasm" #supported assemblers: hifiasm, verkko
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -11,7 +11,7 @@ samples: "config/samples.tsv"
 
 # Whether custom singularity containers can be used. If set to false, not all
 # output will be available.
-custom_singularity: false
+custom_singularity: true
 
 # Assembly settings
 assembler: "hifiasm" #supported assemblers: hifiasm, verkko

--- a/workflow/rules/1.assembly/all.smk
+++ b/workflow/rules/1.assembly/all.smk
@@ -16,11 +16,12 @@ rule copy_contigs:
 
 def get_mummerplot_contigs(wildcards):
     filelist = []
-    minlen = config["min_contig_len"]
-    for asmname in get_all_accessions():
-        reference = get_reference_id(asmname)
-        filelist.append(f"results/{asmname}/1.assembly/03.mummer/{asmname}.min{minlen}.vs.{reference}.plot.gp")
-        filelist.append(f"results/{asmname}/1.assembly/03.mummer/{asmname}.min{minlen}.vs.{reference}.plot.large.gp")
+    if singularity_enabled():
+        minlen = config["min_contig_len"]
+        for asmname in get_all_accessions():
+            reference = get_reference_id(asmname)
+            filelist.append(f"results/{asmname}/1.assembly/03.mummer/{asmname}.min{minlen}.vs.{reference}.plot.gp")
+            filelist.append(f"results/{asmname}/1.assembly/03.mummer/{asmname}.min{minlen}.vs.{reference}.plot.large.gp")
     return filelist
 
 rule assemble:

--- a/workflow/rules/2.scaffolding/all.smk
+++ b/workflow/rules/2.scaffolding/all.smk
@@ -16,17 +16,19 @@ rule copy_assembly:
 
 def get_mummerplot_scaffolds(wildcards):
     filelist = []
-    for asmname in get_all_accessions():
-        reference = get_reference_id(asmname)
-        filelist.append(f"results/{asmname}/2.scaffolding/03.mummer/{asmname}.vs.{reference}.plot.gp")
-        filelist.append(f"results/{asmname}/2.scaffolding/03.mummer/{asmname}.vs.{reference}.plot.large.gp")
+    if singularity_enabled():
+        for asmname in get_all_accessions():
+            reference = get_reference_id(asmname)
+            filelist.append(f"results/{asmname}/2.scaffolding/03.mummer/{asmname}.vs.{reference}.plot.gp")
+            filelist.append(f"results/{asmname}/2.scaffolding/03.mummer/{asmname}.vs.{reference}.plot.large.gp")
     return filelist
 
 def get_hic_plots(wildcards):
     filelist = []
-    for asmname in get_all_accessions():
-        if has_hic(asmname):
-            filelist.append(f"results/{asmname}/2.scaffolding/01.{config['scaffolder']}/contact_map.pdf")
+    if singularity_enabled():
+        for asmname in get_all_accessions():
+            if has_hic(asmname):
+                filelist.append(f"results/{asmname}/2.scaffolding/01.{config['scaffolder']}/contact_map.pdf")
     return filelist
 
 rule scaffold:

--- a/workflow/rules/5.quality_assessment/all.smk
+++ b/workflow/rules/5.quality_assessment/all.smk
@@ -88,36 +88,39 @@ def get_mash_output(wildcards):
 
 def get_ntsynt_output(wildcards):
     all_output = []
-    mink = 24
-    minw = 1000
-    for asmset in config["set"]:
-        if (len(get_all_accessions_from_asmset(asmset)) < 2):
-            continue
-        if len(config["set"][asmset]) >= 2:  #synteny only makes sense for multiple genomes
-            all_output.append(f"results/{asmset}/5.quality_assessment/10.ntsynt/{asmset}.k{mink}.w{minw}.png")
+    if singularity_enabled():
+        mink = 24
+        minw = 1000
+        for asmset in config["set"]:
+            if (len(get_all_accessions_from_asmset(asmset)) < 2):
+                continue
+            if len(config["set"][asmset]) >= 2:  #synteny only makes sense for multiple genomes
+                all_output.append(f"results/{asmset}/5.quality_assessment/10.ntsynt/{asmset}.k{mink}.w{minw}.png")
     return all_output
 
 def get_sans_output(wildcards):
     all_output = []
-    k = config["k_qa"]
-    bootstrap = 1000
-    for asmset in config["set"]:
-        if (len(get_all_accessions_from_asmset(asmset)) < 2):
-            continue
-        if len(config["set"][asmset]) >= 4:  #phylogenetic networks only makes sense for 4+ genomes
-            all_output.append(f"results/{asmset}/5.quality_assessment/11.sans/{k}/{asmset}_b{bootstrap}.nexus")
+    if singularity_enabled():
+        k = config["k_qa"]
+        bootstrap = 1000
+        for asmset in config["set"]:
+            if (len(get_all_accessions_from_asmset(asmset)) < 2):
+                continue
+            if len(config["set"][asmset]) >= 4:  #phylogenetic networks only makes sense for 4+ genomes
+                all_output.append(f"results/{asmset}/5.quality_assessment/11.sans/{k}/{asmset}_b{bootstrap}.nexus")
     return all_output
 
 def get_pangrowth_output(wildcards):
     all_output = []
-    k = config["k_qa"]
-    for asmset in config["set"]:
-        if (len(get_all_accessions_from_asmset(asmset)) < 2):
-            continue
-        if len(config["set"][asmset]) >= 3:
-            all_output.append(f"results/{asmset}/5.quality_assessment/12.pangrowth/{k}/hist.pdf"),  #pangrowth hist
-            all_output.append(f"results/{asmset}/5.quality_assessment/12.pangrowth/{k}/growth.pdf"),  #pangrowth growth
-            all_output.append(f"results/{asmset}/5.quality_assessment/12.pangrowth/{k}/core.pdf"),  #pangrowth core
+    if singularity_enabled():
+        k = config["k_qa"]
+        for asmset in config["set"]:
+            if (len(get_all_accessions_from_asmset(asmset)) < 2):
+                continue
+            if len(config["set"][asmset]) >= 3:
+                all_output.append(f"results/{asmset}/5.quality_assessment/12.pangrowth/{k}/hist.pdf"),  #pangrowth hist
+                all_output.append(f"results/{asmset}/5.quality_assessment/12.pangrowth/{k}/growth.pdf"),  #pangrowth growth
+                all_output.append(f"results/{asmset}/5.quality_assessment/12.pangrowth/{k}/core.pdf"),  #pangrowth core
     return all_output
 
 def get_statistics_output(wildcards):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1,3 +1,9 @@
+def singularity_enabled():
+    """
+    Returns a boolean for whether custom singularity containers may be used.
+    """
+    return config["custom_singularity"]
+
 def get_all_accessions():
     """
     Return all accession IDs.


### PR DESCRIPTION
Not all users may have the ability to create the relevant custom singularity containers since it requires sudo rights. This PR adds a flag to the config which, if set to false, doesn't try running any rules that need these custom containers. This affects the following (all visualisations in report):
- MUMmerplots
- Hi-C contact maps
- ntSynt visualisation
- SANS network construction
- pangrowth calculations