### PR TITLE
Fix error with long line width input fasta

### DIFF
--- a/workflow/rules/1.assembly/all.smk
+++ b/workflow/rules/1.assembly/all.smk
@@ -40,8 +40,10 @@ rule copy_assembly:
         "results/logs/1.assembly/copy_assembly/{asmname}.log"
     benchmark:
         "results/benchmarks/1.assembly/copy_assembly/{asmname}.txt"
+    conda:
+        "../../envs/seqkit.yaml"
     shell:
-        "cp $(realpath {input}) {output} &> {log}"
+        "seqkit seq -w 80 $(realpath {input}) -o {output} &> {log}"
 
 rule index_scaffolds:
     input:


### PR DESCRIPTION
Since tools like AGAT cannot deal with fasta files that have long lines, we need to ensure that input genomes always have short folded lines. With this merge request, I will limit the line length to 80 basepairs.