### PR TITLE
clean output of previous run when new run of pantools is copied to pr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ All notable changes to MoGAAAP will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Fix re-running pantools, which gave an error when snakemake decided it was necessary to run the same job again (#105).
+
 ### Added
 - Added bioconda installation instructions (#104).
 - Fix paths that were forgotten to be updated in the last release (#102).

--- a/MoGAAAP/workflow/rules/3.quality_assessment/05.pantools.smk
+++ b/MoGAAAP/workflow/rules/3.quality_assessment/05.pantools.smk
@@ -43,6 +43,7 @@ rule panproteome_build:
         (
         mkdir -p {params.tmpdir}
         pantools {params.jvm} build_panproteome --force {params.tmpdir}/panproteome_DB {input}
+        rm -rd $(dirname $(dirname {output}))
         mv {params.tmpdir}/panproteome_DB $(dirname $(dirname {output}))
         ) &> {log}"""
 
@@ -71,6 +72,7 @@ rule panproteome_group:
         mkdir -p {params.tmpdir}
         cp -vr $(dirname {input}) {params.tmpdir}/panproteome_groups_DB
         pantools {params.jvm} group --relaxation {params.grouping} --threads {threads} {params.tmpdir}/panproteome_groups_DB
+        rm -rd $(dirname $(dirname {output}))
         mv {params.tmpdir}/panproteome_groups_DB $(dirname $(dirname {output}))/
         ) &> {log}"""
 

--- a/MoGAAAP/workflow/rules/3.quality_assessment/05.pantools.smk
+++ b/MoGAAAP/workflow/rules/3.quality_assessment/05.pantools.smk
@@ -43,7 +43,7 @@ rule panproteome_build:
         (
         mkdir -p {params.tmpdir}
         pantools {params.jvm} build_panproteome --force {params.tmpdir}/panproteome_DB {input}
-        rm -rd $(dirname $(dirname {output}))
+        rm -rd $(dirname {output})
         mv {params.tmpdir}/panproteome_DB $(dirname $(dirname {output}))
         ) &> {log}"""
 
@@ -72,7 +72,7 @@ rule panproteome_group:
         mkdir -p {params.tmpdir}
         cp -vr $(dirname {input}) {params.tmpdir}/panproteome_groups_DB
         pantools {params.jvm} group --relaxation {params.grouping} --threads {threads} {params.tmpdir}/panproteome_groups_DB
-        rm -rd $(dirname $(dirname {output}))
+        rm -rd $(dirname {output})
         mv {params.tmpdir}/panproteome_groups_DB $(dirname $(dirname {output}))/
         ) &> {log}"""
 


### PR DESCRIPTION
Currently when MoGAAAP wants to rerun pantools build_panproteome or group, it complains that the output directory already exists. This is not handled by snakemake like the other rules because pantools writes entire directories, not single files. With this PR, I explicitly remove the output directory before moving the new one there.