### PR TITLE
Add hint for ONT-only assembly to FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,10 @@ We use strict matching to rename the chromosomes, so the names have to be exactl
 A: While `seqtk` is more accurate in the boundaries of the telomere search, it cannot identify telomeres that are not at the ends of the chromosomes.
 Therefore, we recommend to *also* run BLASTN with a fasta file containing 100x the telomere repeat sequence for identification of telomeres that are not at the ends of the chromosomes.
 
+### Q: I only have ONT data and no HiFi data; can I still use this pipeline?
+A: MoGAAAP does not support ONT-only assemblies (yet), but it is possible to create your own assembly and then give it to MoGAAAP in the `assemblyLocation` field of the sample sheet.
+This way, you can still use MoGAAAP to run the annotation and quality assessment modules.
+
 ### Contact
 If the above information does not answer your question or solve your issue, feel free to open an issue on this GitHub page.
 


### PR DESCRIPTION
As some people only have ONT data that they want to use for genome assembly, there is a need for allowing ONT-only assembly. However, this is still very hard to automate given the currently implemented assembly algorithms. Until this becomes better, I add a section to the FAQ explaining how an ONT-only assembly can still be used for further analysis using MoGAAAP.