### PR TITLE
Update GH actions

### DIFF
--- a/.github/workflows/push_containers.yml
+++ b/.github/workflows/push_containers.yml
@@ -11,8 +11,37 @@ permissions:
     packages: write
 
 jobs:
+    detect-changes:
+        runs-on: ubuntu-latest
+        outputs:
+            changed-def-files: ${{ steps.changes.outputs.changed-def-files }}
+            workflow-changed: ${{ steps.changes.outputs.workflow-changed }}
+        steps:
+            - name: Checkout the code
+              uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
+
+            - name: Detect changes
+              id: changes
+              run: |
+                  # Check if workflow file changed
+                  if git diff --name-only HEAD~1 HEAD | grep -q "^\.github/workflows/push_containers\.yml$"; then
+                    echo "workflow-changed=true" >> $GITHUB_OUTPUT
+                    echo "Workflow changed - will build all containers"
+                  else
+                    echo "workflow-changed=false" >> $GITHUB_OUTPUT
+                  fi
+                  
+                  # Get changed .def files
+                  changed_def_files=$(git diff --name-only HEAD~1 HEAD | grep "^MoGAAAP/workflow/singularity/.*\.def$" | tr '\n' ' ' | sed 's/ $//')
+                  echo "changed-def-files=${changed_def_files}" >> $GITHUB_OUTPUT
+                  echo "Changed .def files: ${changed_def_files}"
+
     build-and-push:
         runs-on: ubuntu-latest
+        needs: detect-changes
+        if: needs.detect-changes.outputs.changed-def-files != '' || needs.detect-changes.outputs.workflow-changed == 'true'
         steps:
             - name: Checkout the code
               uses: actions/checkout@v3
@@ -38,9 +67,23 @@ jobs:
                   repo_name=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
                   cd MoGAAAP/workflow/singularity
                   echo '{"type":"container"}' > config.json
-                  for def_file in */*.def; do
-                    container_name=$(basename "${def_file}" .def | tr '[:upper:]' '[:lower:]')
-                    sudo singularity build "${container_name}.sif" "${def_file}"
-                    oras push --artifact-type application/vnd.sylabs.sif.layer.v1.sif --config config.json:application/vnd.sylabs.sif.config.v1+json ghcr.io/${repo_name}/${container_name}:latest "${container_name}.sif:application/vnd.sylabs.sif.layer.v1.sif"
-
+                  
+                  # Determine which files to process
+                  if [ "${{ needs.detect-changes.outputs.workflow-changed }}" = "true" ]; then
+                    echo "Workflow changed - building all containers"
+                    def_files=$(find . -name "*.def" -type f)
+                  else
+                    echo "Building only changed containers"
+                    def_files="${{ needs.detect-changes.outputs.changed-def-files }}"
+                    def_files=$(echo "$def_files" | sed 's|MoGAAAP/workflow/singularity/||g')
+                  fi
+                  
+                  # Build and push containers
+                  for def_file in $def_files; do
+                    if [ -f "$def_file" ]; then
+                      echo "Processing: $def_file"
+                      container_name=$(basename "${def_file}" .def | tr '[:upper:]' '[:lower:]')
+                      sudo singularity build "${container_name}.sif" "${def_file}"
+                      oras push --artifact-type application/vnd.sylabs.sif.layer.v1.sif --config config.json:application/vnd.sylabs.sif.config.v1+json ghcr.io/${repo_name}/${container_name}:latest "${container_name}.sif:application/vnd.sylabs.sif.layer.v1.sif"
+                    fi
                   done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 All notable changes to MoGAAAP will be documented in this file.
 
+## [Unreleased]
+
+## Changed
+- Update GH actions to only rebuild the SIF containers that have changed (#112).
+
 ## [1.0.2 - 2025-05-02]
 
 ### Fixed


### PR DESCRIPTION
To prevent gh actions from rebuilding all sif containers when only one is changed, we need to update the actions. Doing that here.